### PR TITLE
Instant "edit with form" tab on saving #default_form

### DIFF
--- a/includes/PF_AutoeditAPI.php
+++ b/includes/PF_AutoeditAPI.php
@@ -570,7 +570,10 @@ class PFAutoeditAPI extends ApiBase {
 				$responseText = wfMessage( 'pf_autoedit_success', $this->mOptions['target'], $this->mOptions['form'] )->parse();
 				// Force a HTMLCacheUpdate to prevent the page from missing the 'Edit with form'-tab.
 				// @see https://phabricator.wikimedia.org/T195281
-				$deferedHTMLCacheUpdate = new HTMLCacheUpdate( Title::newFromText( $this->mOptions['target'], 'pagelinks' );
+				$deferedHTMLCacheUpdate = new HTMLCacheUpdate( 
+					Title::newFromText( $this->mOptions['target'] ), 
+					'pagelinks' 
+				);
 				DeferredUpdates::addUpdate( $deferedHTMLCacheUpdate );
 				DeferredUpdates::doUpdates();
 			} else {

--- a/includes/PF_AutoeditAPI.php
+++ b/includes/PF_AutoeditAPI.php
@@ -568,6 +568,11 @@ class PFAutoeditAPI extends ApiBase {
 				$responseText = MessageCache::singleton()->parse( $this->mOptions['ok text'], Title::newFromText( $this->mOptions['target'] ) )->getText();
 			} elseif ( $this->mAction === self::ACTION_SAVE ) {
 				$responseText = wfMessage( 'pf_autoedit_success', $this->mOptions['target'], $this->mOptions['form'] )->parse();
+				// Force a HTMLCacheUpdate to prevent the page from missing the 'Edit with form'-tab.
+				// @see https://phabricator.wikimedia.org/T195281
+				$deferedHTMLCacheUpdate = new HTMLCacheUpdate( Title::newFromText( $this->mOptions['target'], 'pagelinks' );
+				DeferredUpdates::addUpdate( $deferedHTMLCacheUpdate );
+				DeferredUpdates::doUpdates();
 			} else {
 				$responseText = null;
 			}


### PR DESCRIPTION
The HTMLCacheUpdate should be executable directly after the page has been created, otherwise the tab will be missing.

See: https://phabricator.wikimedia.org/T195281