### PR TITLE
Fixes broken address input for map input types

### DIFF
--- a/libs/PF_maps.js
+++ b/libs/PF_maps.js
@@ -153,7 +153,7 @@ function setupMapFormInput( inputDiv, mapService ) {
 		}
 	});
 
-	inputDiv.find('.pfAddressInput').keypress( function( e ) {
+	inputDiv.find('.pfAddressInput > input').keypress( function( e ) {
 		// Is this still necessary fro IE compatibility?
 		var keycode = (e.keyCode ? e.keyCode : e.which);
 		if ( keycode == 13 ) {
@@ -223,7 +223,7 @@ function setupMapFormInput( inputDiv, mapService ) {
 			var addressText = allFeedersForCurrentMap.join( ', ' );
 		} else {
 			// No other inputs feed to this map, so use the standard "Enter address here" input.
-			var addressText = inputDiv.find('.pfAddressInput').val();
+			var addressText = inputDiv.find('.pfAddressInput > input').val();
 		}
 		if ( mapService === "Google Maps" ) {
 			geocoder.geocode( { 'address': addressText }, function(results, status) {


### PR DESCRIPTION
The migration to `OOUI\TextInputWidget` at `PF_OpenLayersInput.php` did break the geolocation address input (`.pfAddressInput`).

The OOUI wraps the actual input tag into a container and adds the classes to the container, not to the input, in a result the JS code is unable to find the input same as it is unable to correctly handle key events on a wrapper.