### PR TITLE
Update PF_ValuesUtils.php

### DIFF
--- a/includes/PF_ValuesUtils.php
+++ b/includes/PF_ValuesUtils.php
@@ -231,7 +231,7 @@ class PFValuesUtils {
 						]
 					];
 					if ( $substring != null ) {
-						$conditions[] = '(pp_displaytitle.pp_value IS NULL AND (' .
+						$conditions[] = '(pp_displaytitle.pp_value IS NULL OR pp_displaytitle.pp_value = \'\' AND (' .
 							self::getSQLConditionForAutocompleteInColumn( 'page_title', $substring ) .
 							')) OR ' .
 							self::getSQLConditionForAutocompleteInColumn( 'pp_displaytitle.pp_value', $substring ) .


### PR DESCRIPTION
Fixes a bug where sometimes the displaytitle property would not be null but empty, thus resulting in titles not being found through the autocomplete API