### PR TITLE
Add a way to disable edit warning

### DIFF
--- a/includes/PF_Hooks.php
+++ b/includes/PF_Hooks.php
@@ -153,6 +153,7 @@ class PFHooks {
 		global $wgPageFormsShowOnSelect, $wgPageFormsScriptPath;
 		global $edgValues, $wgPageFormsEDSettings;
 		global $wgAmericanDates;
+		global $wgPageFormsDisableEditWarning;
 
 		$vars['wgPageFormsTargetName'] = $wgPageFormsTargetName;
 		$vars['wgPageFormsAutocompleteValues'] = $wgPageFormsAutocompleteValues;
@@ -179,6 +180,7 @@ class PFHooks {
 		}
 		$vars['wgPageFormsEDSettings'] = $wgPageFormsEDSettings;
 		$vars['wgAmericanDates'] = $wgAmericanDates;
+		$vars['wgPageFormsDisableEditWarning'] = $wgPageFormsDisableEditWarning;
 
 		return true;
 	}

--- a/libs/PF_editWarning.js
+++ b/libs/PF_editWarning.js
@@ -26,6 +26,10 @@
 			return true;
 		}
 
+		if ( mw.config.get( 'wgPageFormsDisableEditWarning' ) ) {
+			return true;
+		}
+
 		// Save the original value of the inputs.
 		$allInputs.each( function ( index, element ) {
 			var $element = $( element );


### PR DESCRIPTION
We wanted to have a way to disable the edit warning on page forms while keeping it on the wikicode edit form so this patch adds a new `$wgPageFormsDisableEditWarning` setting that does that.