### PR TITLE
Update to (single) checkbox input

### DIFF
--- a/includes/forminputs/PF_CheckboxInput.php
+++ b/includes/forminputs/PF_CheckboxInput.php
@@ -69,14 +69,25 @@ class PFCheckboxInput extends PFFormInput {
 		if ( $is_disabled ) {
 			$checkboxAttrs['disabled'] = true;
 		}
-		$text .= "\t" . new OOUI\CheckboxInputWidget( $checkboxAttrs ) . "<t />";
 		if ( isset( $other_args['label'] ) ) {
-			$text = Html::rawElement(
-				'label',
-				[ 'for' => $inputID ],
-				$text . $other_args['label']
-			);
+			$labelText = new OOUI\HtmlSnippet( $other_args['label'] );
+			$labelAttrs = [
+				'label' => $labelText,
+				'align' => 'inline',
+				'for' => $inputID
+			];
+		} else {
+			$labelAttrs = [];
 		}
+		$text .= new OOUI\FieldLayout(
+			new OOUI\CheckboxInputWidget( $checkboxAttrs ),
+			$labelAttrs
+		);
+		$text = Html::rawElement(
+			'div',
+			[ 'class' => 'pf-checkbox-input-container' ],
+			$text
+		);
 		return $text;
 	}
 

--- a/skins/PageForms.css
+++ b/skins/PageForms.css
@@ -112,7 +112,6 @@ form input.formInput,
 #pfForm select,
 #pfForm input[type="checkbox"] {
     max-width: 100%;
-    width: auto !important;
 }
 
 #pfForm label.checkboxLabel {


### PR DESCRIPTION
- Restores having clickable labels again by relying on OOUI's own methods. 
- Css fix 
