### PR TITLE
Update PageForms.css

### DIFF
--- a/skins/PageForms.css
+++ b/skins/PageForms.css
@@ -213,7 +213,6 @@ div.otherForms {
 }
 
 .multipleTemplateInstance {
-	background-color: #eaecf0;
 	border: 1px solid #a2a9b1;
 	padding: 5px;
 	margin: 15px 0 15px 0;


### PR DESCRIPTION
Removing background color for .multipleTemplateInstance, this causes 'multiple' instances to have a background color that conflicts with Dark Mode settings in modern wiki skins. There is no benefit to having this manually declared, it can be overridden with user styles if desired.