### PR TITLE
Use SMW property value type API

### DIFF
--- a/includes/PF_TemplateField.php
+++ b/includes/PF_TemplateField.php
@@ -167,7 +167,7 @@ class PFTemplateField {
 		}
 		$label_formats = PFValuesUtils::getSMWPropertyValues( $store, $proptitle, "Has field label format" );
 		$propValue = \SMW\DIProperty::newFromUserLabel( $this->mSemanticProperty );
-		$this->mPropertyType = $propValue->findPropertyTypeID();
+		$this->mPropertyType = $propValue->findPropertyValueType();
 
 		foreach ( $allowed_values as $allowed_value ) {
 			// HTML-unencode each value


### PR DESCRIPTION
## Summary

- Backport the SMW property value type API call used on master to REL1_45
- Use `findPropertyValueType()` instead of the removed `findPropertyTypeID()`

## Why

PageForms REL1_45 still calls `findPropertyTypeID()` on `\SMW\DIProperty::newFromUserLabel()` results while initializing template fields. With SemanticMediaWiki 7, that object no longer provides `findPropertyTypeID()`, which causes `PFTemplate::newFromName()` to fail when PageForms reads SMW-backed template field definitions.

The master branch already uses `findPropertyValueType()` in this code path. SemanticMediaWiki 6 also provides `findPropertyValueType()`, so the same call is compatible with both SMW 6 and SMW 7.

## Checks

- `php -l includes/PF_TemplateField.php`
- `git diff --check HEAD~1 HEAD`
